### PR TITLE
feat: add HTTP/HTTPS proxy support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 dev/
+venv/
+.venv/


### PR DESCRIPTION
## Add HTTP/HTTPS Proxy Support

### Description
This PR adds proxy support to the scanner, allowing users to route all HTTP/HTTPS requests through a specified proxy server.

### Changes
- Added `-p/--proxy` command-line argument to accept proxy URL
- Modified `send_payload()` function to support proxy configuration
- Modified `resolve_redirects()` function to support proxy configuration
- Updated `.gitignore` to exclude virtual environment directories

### Testing
- Tested with HTTP proxy
- Tested with HTTPS proxy